### PR TITLE
Improve README with module summaries and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,49 @@
 
 We provide codebase to allow readers to reproduce our experiments. This code also contains various utilities related to causal diagram, structural causal model, and multi-armed bandit problem.
 (At this moment, the code is not well-documented.) 
-The code is tested with the following configuration: `python=3.9`, `numpy=1.21.2`, `scipy=1.7.1`, `joblib=1.0.1`, `matplotlib=3.4.3`, `seaborn=0.11.2`, and `networkx=2.6.3`, on
-Linux and MacOS machines.
+
+The code is tested with the following configuration: `python=3.9`, `numpy=1.21.2`,
+`scipy=1.7.1`, `joblib=1.0.1`, `matplotlib=3.4.3`, `seaborn=0.11.2`, and
+`networkx=2.6.3`, on Linux and MacOS machines.
+
+## Getting Started
+
+Install the package in editable mode together with the required dependencies:
+
+```bash
+python -m pip install -e .
+```
+
+After installation the `npsem` module can be imported from anywhere.
+
+## Module Overview
+
+- **bandits.py** – implementations of KL-UCB and Thompson Sampling algorithms and
+  utilities for running bandit simulations.
+- **model.py** – data structures for causal diagrams and structural causal models
+  with simple inference routines.
+- **where_do.py** – algorithms for computing Minimal Intervention Sets (MIS) and
+  POMISs used for deciding where to intervene.
+- **scm_bandits.py** – helpers to convert a structural causal model into a bandit
+  machine and utilities for selecting arms.
+- **utils.py** – small helper functions for randomization, seeding and misc
+  utilities.
+- **viz_util.py** – basic plotting helpers such as sparse index generation.
 
 
-Please run the following command to perform experiments (which will use 3/4 of CPU cores on the machine):
-> `python3 -m npsem.NIPS2018POMIS_exp.test_bandit_strategies`
+## Reproducing the Experiments
 
-This takes less than 30 minutes in a server with 24 cores. This will create `bandit_results` directory and there will be three directories corresponding to each task in the paper.
-Then, run the following to create a figure as in the paper:
-> `python3 -m npsem.NIPS2018POMIS_exp.test_drawing_re`
+Run the following command to execute the bandit experiments (it uses 3/4 of the
+available CPU cores):
+
+```bash
+python3 -m npsem.NIPS2018POMIS_exp.test_bandit_strategies
+```
+
+This step produces a `bandit_results` directory with subdirectories for each of
+the three tasks discussed in the paper. To generate the plots from these
+results run:
+
+```bash
+python3 -m npsem.NIPS2018POMIS_exp.test_drawing_re
+```


### PR DESCRIPTION
## Summary
- clarify installation steps in README
- describe main modules (`bandits`, `model`, `where_do`, etc.)
- document how to run the experiments and plotting script

## Testing
- `python -m pip install -e .` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6869178ee4208320961b3e88163e4140